### PR TITLE
Add guest order persistence

### DIFF
--- a/src/components/OrderListItemComponent/OrderListItem.tsx
+++ b/src/components/OrderListItemComponent/OrderListItem.tsx
@@ -13,7 +13,7 @@ interface OrderListItemProps {
 
 const OrderListItem: React.FC<OrderListItemProps> = ({ order, labels, language }) => {
     const history = useHistory();
-    const { user, guestLastName } = useAppContext();
+    const { user } = useAppContext();
 
     const formatTime = (timestamp: string, language: string): string => {
         const options: Intl.DateTimeFormatOptions = {
@@ -30,7 +30,7 @@ const OrderListItem: React.FC<OrderListItemProps> = ({ order, labels, language }
             onClick={() =>
                 history.push(
                     `/confirmation/${order.id}${
-                        user ? '' : `?lastName=${encodeURIComponent(guestLastName)}`
+                        user ? '' : `?lastName=${encodeURIComponent(order.lastName)}`
                     }`
                 )
             }

--- a/src/components/OrderListItemComponent/OrderListItem.tsx
+++ b/src/components/OrderListItemComponent/OrderListItem.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { IonItem, IonLabel, IonBadge, IonThumbnail } from '@ionic/react';
 import { useHistory } from 'react-router-dom';
 import { baseUrl } from '../../services/apiService';
+import { useAppContext } from '../../context/AppContext';
 import './OrderListItem.css';
 
 interface OrderListItemProps {
@@ -12,6 +13,7 @@ interface OrderListItemProps {
 
 const OrderListItem: React.FC<OrderListItemProps> = ({ order, labels, language }) => {
     const history = useHistory();
+    const { user, guestLastName } = useAppContext();
 
     const formatTime = (timestamp: string, language: string): string => {
         const options: Intl.DateTimeFormatOptions = {
@@ -25,7 +27,13 @@ const OrderListItem: React.FC<OrderListItemProps> = ({ order, labels, language }
         <IonItem
             key={order.id}
             button
-            onClick={() => history.push(`/confirmation/${order.id}`)}
+            onClick={() =>
+                history.push(
+                    `/confirmation/${order.id}${
+                        user ? '' : `?lastName=${encodeURIComponent(guestLastName)}`
+                    }`
+                )
+            }
         >
             <IonLabel>
                 <h2 className="order-header">

--- a/src/context/AppContext.tsx
+++ b/src/context/AppContext.tsx
@@ -12,8 +12,6 @@ interface AppContextType {
     setCart: React.Dispatch<React.SetStateAction<any>>;
     guestOrders: any[];
     setGuestOrders: React.Dispatch<React.SetStateAction<any[]>>;
-    guestLastName: string;
-    setGuestLastName: React.Dispatch<React.SetStateAction<string>>;
     language: string;
     setLanguage: React.Dispatch<React.SetStateAction<string>>;
     orderSubmitted: boolean;
@@ -48,10 +46,6 @@ export const AppProvider: React.FC<{ children: React.ReactNode }> = ({children})
         return storedOrders ? JSON.parse(storedOrders) : [];
     });
 
-    const [guestLastName, setGuestLastName] = useState<string>(() => {
-        const storedLastName = localStorage.getItem('guestLastName');
-        return storedLastName || '';
-    });
 
     const [language, setLanguage] = useState<string>(() => {
         const storedLanguage = localStorage.getItem('language');
@@ -91,13 +85,6 @@ export const AppProvider: React.FC<{ children: React.ReactNode }> = ({children})
         localStorage.setItem('guestOrders', JSON.stringify(guestOrders));
     }, [guestOrders]);
 
-    useEffect(() => {
-        if (guestLastName) {
-            localStorage.setItem('guestLastName', guestLastName);
-        } else {
-            localStorage.removeItem('guestLastName');
-        }
-    }, [guestLastName]);
 
     useEffect(() => {
         localStorage.setItem('language', language);
@@ -131,8 +118,6 @@ export const AppProvider: React.FC<{ children: React.ReactNode }> = ({children})
                 setCart,
                 guestOrders,
                 setGuestOrders,
-                guestLastName,
-                setGuestLastName,
                 language,
                 setLanguage,
                 orderSubmitted,

--- a/src/context/AppContext.tsx
+++ b/src/context/AppContext.tsx
@@ -10,6 +10,8 @@ interface AppContextType {
     setNotifications: React.Dispatch<React.SetStateAction<any>>;
     cart: any;
     setCart: React.Dispatch<React.SetStateAction<any>>;
+    guestOrders: any[];
+    setGuestOrders: React.Dispatch<React.SetStateAction<any[]>>;
     language: string;
     setLanguage: React.Dispatch<React.SetStateAction<string>>;
     orderSubmitted: boolean;
@@ -37,6 +39,11 @@ export const AppProvider: React.FC<{ children: React.ReactNode }> = ({children})
     const [cart, setCart] = useState<any>(() => {
         const storedCart = localStorage.getItem('cart');
         return storedCart ? JSON.parse(storedCart) : null;
+    });
+
+    const [guestOrders, setGuestOrders] = useState<any[]>(() => {
+        const storedOrders = localStorage.getItem('guestOrders');
+        return storedOrders ? JSON.parse(storedOrders) : [];
     });
 
     const [language, setLanguage] = useState<string>(() => {
@@ -74,6 +81,10 @@ export const AppProvider: React.FC<{ children: React.ReactNode }> = ({children})
     }, [cart]);
 
     useEffect(() => {
+        localStorage.setItem('guestOrders', JSON.stringify(guestOrders));
+    }, [guestOrders]);
+
+    useEffect(() => {
         localStorage.setItem('language', language);
     }, [language]);
 
@@ -103,6 +114,8 @@ export const AppProvider: React.FC<{ children: React.ReactNode }> = ({children})
                 setNotifications,
                 cart,
                 setCart,
+                guestOrders,
+                setGuestOrders,
                 language,
                 setLanguage,
                 orderSubmitted,

--- a/src/context/AppContext.tsx
+++ b/src/context/AppContext.tsx
@@ -12,6 +12,8 @@ interface AppContextType {
     setCart: React.Dispatch<React.SetStateAction<any>>;
     guestOrders: any[];
     setGuestOrders: React.Dispatch<React.SetStateAction<any[]>>;
+    guestLastName: string;
+    setGuestLastName: React.Dispatch<React.SetStateAction<string>>;
     language: string;
     setLanguage: React.Dispatch<React.SetStateAction<string>>;
     orderSubmitted: boolean;
@@ -44,6 +46,11 @@ export const AppProvider: React.FC<{ children: React.ReactNode }> = ({children})
     const [guestOrders, setGuestOrders] = useState<any[]>(() => {
         const storedOrders = localStorage.getItem('guestOrders');
         return storedOrders ? JSON.parse(storedOrders) : [];
+    });
+
+    const [guestLastName, setGuestLastName] = useState<string>(() => {
+        const storedLastName = localStorage.getItem('guestLastName');
+        return storedLastName || '';
     });
 
     const [language, setLanguage] = useState<string>(() => {
@@ -85,6 +92,14 @@ export const AppProvider: React.FC<{ children: React.ReactNode }> = ({children})
     }, [guestOrders]);
 
     useEffect(() => {
+        if (guestLastName) {
+            localStorage.setItem('guestLastName', guestLastName);
+        } else {
+            localStorage.removeItem('guestLastName');
+        }
+    }, [guestLastName]);
+
+    useEffect(() => {
         localStorage.setItem('language', language);
     }, [language]);
 
@@ -116,6 +131,8 @@ export const AppProvider: React.FC<{ children: React.ReactNode }> = ({children})
                 setCart,
                 guestOrders,
                 setGuestOrders,
+                guestLastName,
+                setGuestLastName,
                 language,
                 setLanguage,
                 orderSubmitted,

--- a/src/pages/Checkout/Checkout.tsx
+++ b/src/pages/Checkout/Checkout.tsx
@@ -42,7 +42,7 @@ const isWithinWorkingHours = () => {
 };
 
 const Checkout: React.FC = () => {
-    const { setIsLoading, user, cart, language, setOrderSubmitted, setToastColor, setToastMessage, setShowToast, setCart, guestOrders, setGuestOrders } = useAppContext();
+    const { setIsLoading, user, cart, language, setOrderSubmitted, setToastColor, setToastMessage, setShowToast, setCart, guestOrders, setGuestOrders, guestLastName, setGuestLastName } = useAppContext();
     const [isOrderComplete, setIsOrderComplete] = useState(false);
     const [pickupOrDelivery, setPickupOrDelivery] = useState<"pickup" | "delivery">("pickup");
     const [address, setAddress] = useState("");
@@ -131,6 +131,7 @@ const Checkout: React.FC = () => {
                 };
                 createdOrder = await OrderAPI.createGuestOrder(payload);
                 setGuestOrders([...guestOrders, createdOrder]);
+                setGuestLastName(lastName);
             }
 
             setOrderSubmitted(true);

--- a/src/pages/Checkout/Checkout.tsx
+++ b/src/pages/Checkout/Checkout.tsx
@@ -42,7 +42,7 @@ const isWithinWorkingHours = () => {
 };
 
 const Checkout: React.FC = () => {
-    const { setIsLoading, user, cart, language, setOrderSubmitted, setToastColor, setToastMessage, setShowToast, setCart } = useAppContext();
+    const { setIsLoading, user, cart, language, setOrderSubmitted, setToastColor, setToastMessage, setShowToast, setCart, guestOrders, setGuestOrders } = useAppContext();
     const [pickupOrDelivery, setPickupOrDelivery] = useState<"pickup" | "delivery">("pickup");
     const [address, setAddress] = useState("");
     const [phone, setPhone] = useState(user?.phoneNumber || "");
@@ -127,6 +127,7 @@ const Checkout: React.FC = () => {
                     })),
                 };
                 createdOrder = await OrderAPI.createGuestOrder(payload);
+                setGuestOrders([...guestOrders, createdOrder]);
             }
 
             setOrderSubmitted(true);

--- a/src/pages/Checkout/Checkout.tsx
+++ b/src/pages/Checkout/Checkout.tsx
@@ -43,6 +43,7 @@ const isWithinWorkingHours = () => {
 
 const Checkout: React.FC = () => {
     const { setIsLoading, user, cart, language, setOrderSubmitted, setToastColor, setToastMessage, setShowToast, setCart, guestOrders, setGuestOrders } = useAppContext();
+    const [isOrderComplete, setIsOrderComplete] = useState(false);
     const [pickupOrDelivery, setPickupOrDelivery] = useState<"pickup" | "delivery">("pickup");
     const [address, setAddress] = useState("");
     const [phone, setPhone] = useState(user?.phoneNumber || "");
@@ -57,9 +58,11 @@ const Checkout: React.FC = () => {
 
     useEffect(() => {
         if (!cart || cart.items.length === 0) {
-            history.push("/products");
+            if (!isOrderComplete) {
+                history.push("/products");
+            }
         }
-    }, [cart, history]);
+    }, [cart, history, isOrderComplete]);
 
     const calculateRowTotal = (quantity: number, price: number) => quantity * price;
 
@@ -131,6 +134,7 @@ const Checkout: React.FC = () => {
             }
 
             setOrderSubmitted(true);
+            setIsOrderComplete(true);
             setCart(null);
             setAddress("");
             setOrderNotes("");

--- a/src/pages/Checkout/Checkout.tsx
+++ b/src/pages/Checkout/Checkout.tsx
@@ -42,7 +42,7 @@ const isWithinWorkingHours = () => {
 };
 
 const Checkout: React.FC = () => {
-    const { setIsLoading, user, cart, language, setOrderSubmitted, setToastColor, setToastMessage, setShowToast, setCart, guestOrders, setGuestOrders, guestLastName, setGuestLastName } = useAppContext();
+    const { setIsLoading, user, cart, language, setOrderSubmitted, setToastColor, setToastMessage, setShowToast, setCart, guestOrders, setGuestOrders } = useAppContext();
     const [isOrderComplete, setIsOrderComplete] = useState(false);
     const [pickupOrDelivery, setPickupOrDelivery] = useState<"pickup" | "delivery">("pickup");
     const [address, setAddress] = useState("");
@@ -130,8 +130,7 @@ const Checkout: React.FC = () => {
                     })),
                 };
                 createdOrder = await OrderAPI.createGuestOrder(payload);
-                setGuestOrders([...guestOrders, createdOrder]);
-                setGuestLastName(lastName);
+                setGuestOrders([...guestOrders, { ...createdOrder, lastName }]);
             }
 
             setOrderSubmitted(true);

--- a/src/pages/Confirmation/Confirmation.tsx
+++ b/src/pages/Confirmation/Confirmation.tsx
@@ -74,7 +74,7 @@ const Confirmation: React.FC = () => {
                 updatedOrder = await OrderAPI.cancelGuestOrder(id, lastNameParam);
                 setGuestOrders(
                     guestOrders.map((o: any) =>
-                        o.id === updatedOrder.id ? updatedOrder : o
+                        o.id === updatedOrder.id ? { ...updatedOrder, lastName: o.lastName } : o
                     )
                 );
             }

--- a/src/pages/MyOrders/MyOrders.tsx
+++ b/src/pages/MyOrders/MyOrders.tsx
@@ -38,7 +38,7 @@ const groupOrdersByDate = (orders: any[], language: string) => {
 };
 
 const MyOrders: React.FC = () => {
-    const { user, language, orderSubmitted, setOrderSubmitted, setIsLoading } = useAppContext();
+    const { user, language, orderSubmitted, setOrderSubmitted, setIsLoading, guestOrders } = useAppContext();
     const [orders, setOrders] = useState<any[]>([]);
 
     const labels = translations[language];
@@ -62,22 +62,39 @@ const MyOrders: React.FC = () => {
     useEffect(() => {
         if (!user) {
             setIsLoading(false);
-            setOrders([]);
+            const sortedGuestOrders = guestOrders.sort(
+                (a: any, b: any) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
+            );
+            setOrders(sortedGuestOrders);
             return;
         }
 
         fetchOrders();
-    }, [user, setIsLoading]);
+    }, [user, guestOrders, setIsLoading]);
 
     useEffect(() => {
         if (orderSubmitted) {
-            fetchOrders();
+            if (user) {
+                fetchOrders();
+            } else {
+                const sortedGuestOrders = guestOrders.sort(
+                    (a: any, b: any) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
+                );
+                setOrders(sortedGuestOrders);
+            }
             setOrderSubmitted(false);
         }
-    }, [orderSubmitted, setIsLoading]);
+    }, [orderSubmitted, guestOrders, user, setIsLoading]);
 
     const handleRefresh = async (event: CustomEvent) => {
-        await fetchOrders();
+        if (user) {
+            await fetchOrders();
+        } else {
+            const sortedGuestOrders = guestOrders.sort(
+                (a: any, b: any) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
+            );
+            setOrders(sortedGuestOrders);
+        }
         event.detail.complete();
     };
 
@@ -113,7 +130,7 @@ const MyOrders: React.FC = () => {
                     ))
                 ) : (
                     <IonText color="medium" className="ion-text-center">
-                        <h2>{user ? labels.noOrdersFound : labels.notLoggedIn}</h2>
+                        <h2>{user || guestOrders.length > 0 ? labels.noOrdersFound : labels.notLoggedIn}</h2>
                     </IonText>
                 )}
             </IonContent>

--- a/src/services/apiService.ts
+++ b/src/services/apiService.ts
@@ -199,6 +199,12 @@ export const OrderAPI = {
   cancelOrder: (orderId: string): Promise<any> =>
     apiRequest(`/orders/cancel/${orderId}`, { method: "PUT" }),
 
+  cancelGuestOrder: (orderId: string, lastName: string): Promise<any> =>
+    publicRequest(
+      `/orders/guest/cancel/${orderId}?lastName=${encodeURIComponent(lastName)}`,
+      { method: "PUT" }
+    ),
+
   createOrder: (payload: any): Promise<any> =>
     apiRequest(`/orders`, {
       method: "POST",


### PR DESCRIPTION
## Summary
- store guest orders in AppContext and localStorage
- persist guest orders when checking out
- show guest orders on My Orders page when not logged in

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm run test.unit` *(fails: vitest not found)*
- `npm run test.e2e` *(fails: cypress not found)*
- `npm run build` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686fbba0bc1483298e69311c644fabef