### PR TITLE
Limit phone number input length

### DIFF
--- a/src/components/SignUpComponent/SignUpComponent.tsx
+++ b/src/components/SignUpComponent/SignUpComponent.tsx
@@ -99,9 +99,13 @@ const SignUpComponent: React.FC = () => {
                 <IonItem>
                     <IonLabel position="stacked">{labels.phoneNumber}*</IonLabel>
                     <IonInput
+                        type="tel"
+                        maxlength={15}
                         value={phoneNumber}
                         placeholder={labels.enterPhoneNumber}
-                        onIonInput={(e: any) => setPhoneNumber(e.target.value || "")}
+                        onIonInput={(e: any) =>
+                            setPhoneNumber((e.target.value || "").slice(0, 15))
+                        }
                     />
                 </IonItem>
                 <IonItem>

--- a/src/pages/Checkout/Checkout.tsx
+++ b/src/pages/Checkout/Checkout.tsx
@@ -228,9 +228,12 @@ const Checkout: React.FC = () => {
                     <IonLabel position="stacked">{labels.phoneNumber}</IonLabel>
                     <IonInput
                         type="tel"
+                        maxlength={15}
                         value={phone}
                         placeholder={labels.enterYourPhone}
-                        onIonChange={(e) => setPhone(e.detail.value || "")}
+                        onIonChange={(e) =>
+                            setPhone((e.detail.value || "").slice(0, 15))
+                        }
                     />
                 </IonItem>
 

--- a/src/pages/Profile/Profile.tsx
+++ b/src/pages/Profile/Profile.tsx
@@ -281,7 +281,14 @@ const ProfilePage: React.FC = () => {
             </IonItem>
             <IonItem>
               <IonLabel position="stacked">{labels.phoneNumber}*</IonLabel>
-              <IonInput value={updatedPhoneNumber} onIonChange={(e) => setUpdatedPhoneNumber(e.detail.value!)} />
+              <IonInput
+                type="tel"
+                maxlength={15}
+                value={updatedPhoneNumber}
+                onIonChange={(e) =>
+                  setUpdatedPhoneNumber((e.detail.value || '').slice(0, 15))
+                }
+              />
             </IonItem>
             <IonItem className="privacy-notice-item">
               <input


### PR DESCRIPTION
## Summary
- cap phone fields at 15 characters across the UI

## Testing
- `npm run lint` *(fails: ESLint couldn't find configuration)*
- `npm run test.unit` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687bac02ac5c8329bd858d052ba906ff